### PR TITLE
fix: remove duplicate pnpm version from CI workflows

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Removed hardcoded `version: 10` from `pnpm/action-setup@v4` in both `build.yml` and `build-and-publish.yml`
- The action now reads the pnpm version from `packageManager: pnpm@10.32.1` in `package.json`, which is the single source of truth

Fixes the GitHub Actions error:
```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.32.1 in the package.json with the key "packageManager"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)